### PR TITLE
Fix fs.writeFileSync() not writing binary data and related bugs.

### DIFF
--- a/amdtweak.js
+++ b/amdtweak.js
@@ -203,7 +203,7 @@ class Commander {
     var cards = [];
     for (var i = 0; i < args.length; i++)
       this.addCardBySelector(args[i]);
-
+    
     if (this.cards === 0)
       this.warning("No cards selected, the following operations will have no effect");
   }
@@ -283,7 +283,7 @@ class Commander {
       }
 
       vbios.$updateObject({ buffer: ppBuf, object: ppObj, log: this.warning.bind(this) });
-      if (iofs.writeFile(fileName, ppBuf)) {
+      if (iofs.writeFileBinary(fileName, ppBuf)) {
         this.verbose(`Card '${id}' PP data written to '${fileName}'`);
       }
       else {
@@ -338,12 +338,12 @@ class Commander {
         continue;
       }
 
-      vbios.$updateObject({ buffer: ppBuf, object: ppObj, log: this.warning.bind(this) });
-      if (iofs.writeFile(fileName, ppBuf)) {
+//      vbios.$updateObject({ buffer: ppBuf, object: ppObj, log: this.warning.bind(this) }); // WHY ?
+      if (iofs.writeFileBinary(fileName, ppBuf)) {
         this.verbose(`Card '${id}' PP data written to '${fileName}'`);
       }
       else {
-        this.warning(`Couldn't write PP table of card '${id}', are you root?`);
+        this.warning(`Couldn't write PP table of card '${id}' to file '${fileName}', do you have write access?`);
       }
     }
   }
@@ -420,7 +420,7 @@ class Commander {
         this.warning(`Couldn't extract BIOS of card '${id}, are you root?`);
       }
       else {
-        if (!iofs.writeFile(fileName, buf))
+        if (!iofs.writeFileBinary(fileName, buf))
           this.warning(`Couldn't write to '${fileName}'`);
       }
     }
@@ -452,7 +452,7 @@ class Commander {
           this.warning(`Couldn't extract PowerPlay from BIOS of card '${id}', please report this!`);
         }
         else {
-          if (!iofs.writeFile(fileName, pp))
+          if (!iofs.writeFileBinary(fileName, pp))
             this.warning(`Couldn't write to '${fileName}'`);
         }
       }

--- a/lib/iofs.js
+++ b/lib/iofs.js
@@ -143,9 +143,20 @@ function readProperties(fileName) {
 }
 iofs.readProperties = readProperties;
 
+function writeFileBinary(fileName, value) {
+  try {
+    fs.writeFileSync(fileName, value, {mode: 0o644, flag: 'w'} );
+    return true;
+  }
+  catch (ex) {
+    return false;
+  }
+}
+iofs.writeFileBinary = writeFileBinary;
+
 function writeFile(fileName, value, encoding) {
   try {
-    fs.writeFileSync(fileName, String(value), encoding);
+    fs.writeFileSync(fileName, String(value), {encoding: encoding, mode: 0o644, flag: 'w'});
     return true;
   }
   catch (ex) {
@@ -155,7 +166,7 @@ function writeFile(fileName, value, encoding) {
 iofs.writeFile = writeFile;
 
 function writeString(fileName, value) {
-  return writeFile(fileName, value, "UTF-8");
+  return writeFile(fileName, value, 'utf8');
 }
 iofs.writeString = writeString;
 


### PR DESCRIPTION
Hi,

I have write some patch to 'amdtweak.js' and 'iofs.js' to fix the write related bug.
I have tested the patch on pp_table files extracted from AMD RX 560 and AMD RX480/RX580.

I will test this also on AMD RX VEGA 56/64.
I will test writing back pp_table to /sys/.... for all those cards.

best regards,

Samuel